### PR TITLE
feat: add support for custom mermaid versions via remote cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 mermaid.zip
 zips
 build.txt
+
+# Jetbrains
+.idea/

--- a/mermaid.php
+++ b/mermaid.php
@@ -6,66 +6,62 @@ use \Typemill\Plugin;
 
 class Mermaid extends Plugin
 {
-	protected $settings;
-	
+
     public static function getSubscribedEvents()
     {
-		return array(
-			'onSettingsLoaded'		=> 'onSettingsLoaded',		
-			'onTwigLoaded' 			=> 'onTwigLoaded'
-		);
+        return array(
+            'onTwigLoaded' => 'onTwigLoaded'
+        );
     }
-	
-	public function onSettingsLoaded($settings)
-	{
-		$this->settings = $settings->getData();
-	}
-	
-	
-	public function onTwigLoaded()
-	{
-		$mermaidSettings = $this->settings['settings']['plugins']['mermaid'];
-		
-		if (isset($mermaidSettings['theme'])) {
-			$theme = $mermaidSettings['theme'];
-		} else {
-			$theme = 'default';
-		}
-		
-		if (isset($mermaidSettings['securityLevel'])) {
-			$securityLevel = $mermaidSettings['securityLevel'];
-		} else {
-			$securityLevel = 'strict';
-		}
-		
-		if (isset($mermaidSettings['htmlLabels'])) {
-			$htmlLabels = $mermaidSettings['htmlLabels'];
-		} else {
-			$htmlLabels = 'true';
-		}
-		
-		if (isset($mermaidSettings['fontFamily'])) {
-			$fontFamily = $mermaidSettings['fontFamily'];
-		} else {
-			$fontFamily = '';
-		}
-		
-		$this->addJS('/mermaid/public/mermaid.min.js');
-	
-		/* initialize the script */
-		$this->addInlineJS('
-		document.addEventListener("DOMContentLoaded", function() {
-			document.querySelectorAll("code.language-mermaid").forEach(function(element, index) {
-				var content = element.innerHTML.replace(/&amp;/g, "&");
-				tempDiv = document.createElement("div");
-				tempDiv.className = "mermaid";
-				tempDiv.align = "center";
-				tempDiv.innerHTML = content;
-				element.parentNode.parentNode.replaceChild(tempDiv, element.parentNode);
+
+    public function onTwigLoaded()
+    {
+        $mermaidSettings = $this->getPluginSettings();
+
+        if (isset($mermaidSettings['theme'])) {
+            $theme = $mermaidSettings['theme'];
+        } else {
+            $theme = 'default';
+        }
+
+        if (isset($mermaidSettings['securityLevel'])) {
+            $securityLevel = $mermaidSettings['securityLevel'];
+        } else {
+            $securityLevel = 'strict';
+        }
+
+        if (isset($mermaidSettings['htmlLabels'])) {
+            $htmlLabels = $mermaidSettings['htmlLabels'];
+        } else {
+            $htmlLabels = 'true';
+        }
+
+        if (isset($mermaidSettings['fontFamily'])) {
+            $fontFamily = $mermaidSettings['fontFamily'];
+        } else {
+            $fontFamily = '';
+        }
+
+        if (isset($mermaidSettings['mermaidVersion']) && !empty($mermaidSettings['mermaidVersion'])) {
+            $this->addJS('//unpkg.com/mermaid@' . $mermaidSettings['mermaidVersion'] . '/dist/mermaid.min.js');
+        } else {
+            $this->addJS('/mermaid/public/mermaid.min.js');
+        }
+
+        /* initialize the script */
+        $this->addInlineJS('
+			document.addEventListener("DOMContentLoaded", function() {
+				document.querySelectorAll("code.language-mermaid").forEach(function(element, index) {
+					var content = element.innerHTML.replace(/&amp;/g, "&");
+					tempDiv = document.createElement("div");
+					tempDiv.className = "mermaid";
+					tempDiv.align = "center";
+					tempDiv.innerHTML = content;
+					element.parentNode.parentNode.replaceChild(tempDiv, element.parentNode);
+				});
 			});
-		});
 		');
-		
-		$this->addInlineJS("mermaid.initialize({'theme': '".$theme."', 'securityLevel': '".$securityLevel."', 'htmlLabels': ".$htmlLabels.", 'fontFamily': '".$fontFamily."'});");
-	}
+
+        $this->addInlineJS("mermaid.initialize({'theme': '" . $theme . "', 'securityLevel': '" . $securityLevel . "', 'htmlLabels': " . $htmlLabels . ", 'fontFamily': '" . $fontFamily . "'});");
+    }
 }

--- a/mermaid.yaml
+++ b/mermaid.yaml
@@ -1,8 +1,8 @@
 name: Mermaid
-version: 1.0.1
-description: View your mermaid code with the famous mermaid.js library.
-author: Jeong-Ho, Eun
-homepage: https://mermaid-js.github.io/mermaid/#/
+version: 2.1.0
+description: View your mermaid code with the famous mermaid.js library (https://mermaid-js.github.io/mermaid/#/)
+author: "Jeong-Ho Eun, Giuseppe Chiesa"
+homepage: https://github.com/typemill-resources/typemill-plugins-mermaid
 licence: MIT
 
 settings:
@@ -10,6 +10,11 @@ settings:
 
 forms:
   fields:
+
+    mermaidVersion:
+      type: text
+      label: The version in the form (`x.y.z`) of Mermaid you want to embed in your blog. Check the available versions on https://github.com/mermaid-js/mermaid/releases
+      placeholder: "10.9.0"
 
     theme:
       type: select


### PR DESCRIPTION
### Add the support for custom mermaid version 

With this PR mermaid plugin supports an additional field, that will enable remote CDN import of mermaid-js.

This allow to easily onboard new mermaid capabilities by pinning the required version.

If the field is not set, the embedded mermaid version will be used.